### PR TITLE
feat: [SPLT-2862] adiciona suporte a excludedTollTypes e multiplier no sdk

### DIFF
--- a/toll-schema/src/main/java/global/maplink/toll/schema/request/LegRequest.java
+++ b/toll-schema/src/main/java/global/maplink/toll/schema/request/LegRequest.java
@@ -22,6 +22,8 @@ public class LegRequest {
 
     private Condition condition;
 
+    private Integer multiplier;
+
     @Singular
     private List<Coordinates> points;
 

--- a/toll-schema/src/main/java/global/maplink/toll/schema/request/TollCalculationRequest.java
+++ b/toll-schema/src/main/java/global/maplink/toll/schema/request/TollCalculationRequest.java
@@ -8,6 +8,7 @@ import global.maplink.http.request.Request;
 import global.maplink.http.request.RequestBody;
 import global.maplink.json.JsonMapper;
 import global.maplink.toll.schema.Billing;
+import global.maplink.toll.schema.TollType;
 import global.maplink.toll.schema.result.TollCalculationResult;
 import lombok.*;
 
@@ -34,6 +35,9 @@ public class TollCalculationRequest implements MapLinkServiceRequest<TollCalcula
 
     @Builder.Default
     private final boolean inactive = false;
+
+    @Builder.Default
+    private final Set<TollType> excludedTollTypes = new HashSet<>();
 
     @Override
     public Request asHttpRequest(Environment environment, JsonMapper mapper) {

--- a/toll-schema/src/main/java/global/maplink/toll/schema/result/CalculationDetail.java
+++ b/toll-schema/src/main/java/global/maplink/toll/schema/result/CalculationDetail.java
@@ -34,4 +34,5 @@ public class CalculationDetail {
     private final String entryGantryId;
     private final String entryGantryName;
     private final boolean active;
+    private final Integer multiplier;
 }

--- a/toll-schema/src/test/java/global/maplink/toll/schema/request/TollCalculationRequestTest.java
+++ b/toll-schema/src/test/java/global/maplink/toll/schema/request/TollCalculationRequestTest.java
@@ -3,6 +3,7 @@ package global.maplink.toll.schema.request;
 import global.maplink.json.JsonMapper;
 import global.maplink.toll.schema.Coordinates;
 import global.maplink.toll.schema.TollConditionPeriod;
+import global.maplink.toll.schema.TollType;
 import lombok.val;
 import org.junit.jupiter.api.Test;
 
@@ -15,6 +16,8 @@ import static global.maplink.commons.TransponderOperator.SEM_PARAR;
 import static global.maplink.toll.schema.Billing.FREE_FLOW;
 import static global.maplink.toll.schema.TollConditionBillingType.TAG;
 import static global.maplink.toll.schema.TollConditionPeriod.HOLIDAY;
+import static global.maplink.toll.schema.TollType.ENTRY_GANTRY;
+import static global.maplink.toll.schema.TollType.TOLL_GANTRY;
 import static global.maplink.toll.schema.TollVehicleType.CAR;
 import static global.maplink.toll.testUtils.SampleFiles.*;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -119,6 +122,35 @@ class TollCalculationRequestTest {
         val data = mapper.fromJson(CALCULATION_REQUEST.load(), TollCalculationRequest.class);
 
         assertThat(data.isInactive()).isFalse();
+    }
+
+    @Test
+    void shouldDeserializeWithExcludedTollTypes() {
+        val data = mapper.fromJson(CALCULATION_REQUEST_EXCLUDED_TOLL_TYPES.load(), TollCalculationRequest.class);
+
+        assertThat(data.getExcludedTollTypes()).containsExactlyInAnyOrder(TOLL_GANTRY, ENTRY_GANTRY);
+    }
+
+    @Test
+    void shouldDefaultExcludedTollTypesToEmpty() {
+        val data = mapper.fromJson(CALCULATION_REQUEST.load(), TollCalculationRequest.class);
+
+        assertThat(data.getExcludedTollTypes()).isEmpty();
+    }
+
+    @Test
+    void shouldDeserializeLegWithMultiplier() {
+        val data = mapper.fromJson(CALCULATION_REQUEST_WITH_MULTIPLIER.load(), TollCalculationRequest.class);
+
+        assertThat(data.getLegs()).hasSize(1);
+        assertThat(data.getLegs().get(0).getMultiplier()).isEqualTo(2);
+    }
+
+    @Test
+    void shouldDeserializeLegWithNullMultiplierByDefault() {
+        val data = mapper.fromJson(CALCULATION_REQUEST.load(), TollCalculationRequest.class);
+
+        assertThat(data.getLegs().get(0).getMultiplier()).isNull();
     }
 
     private void assertPoint(Coordinates point, double lat, double lon) {

--- a/toll-schema/src/test/java/global/maplink/toll/schema/result/CalculationDetailTest.java
+++ b/toll-schema/src/test/java/global/maplink/toll/schema/result/CalculationDetailTest.java
@@ -99,4 +99,18 @@ public class CalculationDetailTest {
 
         assertTrue(calculationDetail.isActive());
     }
+
+    @Test
+    void shouldDeserializeMultiplierField() {
+        CalculationDetail calculationDetail = mapper.fromJson(CALCULATION_DETAIL.load(), CalculationDetail.class);
+
+        assertEquals(2, calculationDetail.getMultiplier());
+    }
+
+    @Test
+    void shouldDefaultMultiplierToNull() {
+        CalculationDetail calculationDetail = mapper.fromJson(EXIT_GANTRY_DETAIL.load(), CalculationDetail.class);
+
+        assertNull(calculationDetail.getMultiplier());
+    }
 }

--- a/toll-schema/src/test/java/global/maplink/toll/testUtils/SampleFiles.java
+++ b/toll-schema/src/test/java/global/maplink/toll/testUtils/SampleFiles.java
@@ -24,7 +24,9 @@ public enum SampleFiles {
     CALCULATION_DATE_DEFAULT("toll/json/calculationDate.json"),
     CALCULATION_CONDITIONS_DEFAULT("toll/json/calculationConditionsDefault.json"),
     CALCULATION_DEFAULT("toll/json/calculationDefault.json"),
-    CALCULATION_REQUEST_INACTIVE("toll/json/calculationRequestInactive.json");
+    CALCULATION_REQUEST_INACTIVE("toll/json/calculationRequestInactive.json"),
+    CALCULATION_REQUEST_EXCLUDED_TOLL_TYPES("toll/json/calculationRequestExcludedTollTypes.json"),
+    CALCULATION_REQUEST_WITH_MULTIPLIER("toll/json/calculationRequestWithMultiplier.json");
 
     private final String filePath;
 

--- a/toll-schema/src/test/resources/toll/json/calculationDetail.json
+++ b/toll-schema/src/test/resources/toll/json/calculationDetail.json
@@ -33,5 +33,6 @@
       "value": 149.8
     }
   ],
-  "active": true
+  "active": true,
+  "multiplier": 2
 }

--- a/toll-schema/src/test/resources/toll/json/calculationRequestExcludedTollTypes.json
+++ b/toll-schema/src/test/resources/toll/json/calculationRequestExcludedTollTypes.json
@@ -1,0 +1,19 @@
+{
+  "billing": "FREE_FLOW",
+  "excludedTollTypes": ["TOLL_GANTRY", "ENTRY_GANTRY"],
+  "legs": [
+    {
+      "vehicleType": "CAR",
+      "points": [
+        {
+          "latitude": -22.0539,
+          "longitude": -42.36768
+        },
+        {
+          "latitude": -22.05251,
+          "longitude": -42.35759
+        }
+      ]
+    }
+  ]
+}

--- a/toll-schema/src/test/resources/toll/json/calculationRequestWithMultiplier.json
+++ b/toll-schema/src/test/resources/toll/json/calculationRequestWithMultiplier.json
@@ -1,0 +1,19 @@
+{
+  "billing": "FREE_FLOW",
+  "legs": [
+    {
+      "vehicleType": "CAR",
+      "multiplier": 2,
+      "points": [
+        {
+          "latitude": -22.0539,
+          "longitude": -42.36768
+        },
+        {
+          "latitude": -22.05251,
+          "longitude": -42.35759
+        }
+      ]
+    }
+  ]
+}

--- a/trip-schema/src/main/java/global/maplink/trip/schema/v2/problem/TollRequest.java
+++ b/trip-schema/src/main/java/global/maplink/trip/schema/v2/problem/TollRequest.java
@@ -3,6 +3,7 @@ package global.maplink.trip.schema.v2.problem;
 import global.maplink.commons.TransponderOperator;
 import global.maplink.toll.schema.Billing;
 import global.maplink.toll.schema.Condition;
+import global.maplink.toll.schema.TollType;
 import global.maplink.toll.schema.TollVehicleType;
 import global.maplink.trip.schema.v1.exception.violations.VariableAxlesOverlappingViolation;
 import global.maplink.trip.schema.v1.exception.violations.VariableAxlesSiteIdNotFoundInProblem;
@@ -39,7 +40,10 @@ public class TollRequest implements Validable {
     private final Condition condition;
     @Builder.Default
     private final boolean inactive = false;
-    
+    @Builder.Default
+    private final Set<TollType> excludedTollTypes = new HashSet<>();
+    private final Integer multiplier;
+
     @Override
     public List<ValidationViolation> validate() {
         List<ValidationViolation> errors = new ArrayList<>();

--- a/trip-schema/src/test/java/global/maplink/trip/schema/v2/problem/TollRequestTest.java
+++ b/trip-schema/src/test/java/global/maplink/trip/schema/v2/problem/TollRequestTest.java
@@ -14,6 +14,8 @@ import java.util.HashSet;
 
 import static global.maplink.commons.TransponderOperator.CONECTCAR;
 import static global.maplink.commons.TransponderOperator.SEM_PARAR;
+import static global.maplink.toll.schema.TollType.ENTRY_GANTRY;
+import static global.maplink.toll.schema.TollType.TOLL_GANTRY;
 import static global.maplink.trip.testUtils.ProblemSampleFiles.*;
 import static global.maplink.trip.testUtils.ProblemSampleFiles.TOLL_REQUEST_INACTIVE;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -54,6 +56,30 @@ public class TollRequestTest {
     public void shouldDefaultInactiveToFalse() {
         TollRequest tollRequest = mapper.fromJson(TOLL_REQUEST.load(), TollRequest.class);
         assertThat(tollRequest.isInactive()).isFalse();
+    }
+
+    @Test
+    public void shouldDeserializeWithExcludedTollTypes() {
+        TollRequest tollRequest = mapper.fromJson(TOLL_REQUEST_EXCLUDED_TOLL_TYPES.load(), TollRequest.class);
+        assertThat(tollRequest.getExcludedTollTypes()).containsExactlyInAnyOrder(TOLL_GANTRY, ENTRY_GANTRY);
+    }
+
+    @Test
+    public void shouldDefaultExcludedTollTypesToEmpty() {
+        TollRequest tollRequest = mapper.fromJson(TOLL_REQUEST.load(), TollRequest.class);
+        assertThat(tollRequest.getExcludedTollTypes()).isEmpty();
+    }
+
+    @Test
+    public void shouldDeserializeWithMultiplier() {
+        TollRequest tollRequest = mapper.fromJson(TOLL_REQUEST_MULTIPLIER.load(), TollRequest.class);
+        assertThat(tollRequest.getMultiplier()).isEqualTo(3);
+    }
+
+    @Test
+    public void shouldDefaultMultiplierToNull() {
+        TollRequest tollRequest = mapper.fromJson(TOLL_REQUEST.load(), TollRequest.class);
+        assertThat(tollRequest.getMultiplier()).isNull();
     }
 
     @Test

--- a/trip-schema/src/test/java/global/maplink/trip/testUtils/ProblemSampleFiles.java
+++ b/trip-schema/src/test/java/global/maplink/trip/testUtils/ProblemSampleFiles.java
@@ -15,6 +15,8 @@ public enum ProblemSampleFiles {
     TOLL_REQUEST("trip/v2/problem/json/tollRequest.json"),
     TOLL_REQUEST_CONECTCAR("trip/v2/problem/json/tollRequest_Conectcar.json"),
     TOLL_REQUEST_INACTIVE("trip/v2/problem/json/tollRequest_Inactive.json"),
+    TOLL_REQUEST_EXCLUDED_TOLL_TYPES("trip/v2/problem/json/tollRequest_ExcludedTollTypes.json"),
+    TOLL_REQUEST_MULTIPLIER("trip/v2/problem/json/tollRequest_Multiplier.json"),
     TRIP_REQUEST("trip/v2/problem/json/tripRequest.json"),
     TRIP_REQUEST_DEFAULT("trip/v2/problem/json/tripRequestCalculationModeDefault.json"),
     PROBLEM_VARIABLE_AXLES("trip/v2/problem/json/problem_VariableAxles.json"),

--- a/trip-schema/src/test/resources/trip/v2/problem/json/tollRequest_ExcludedTollTypes.json
+++ b/trip-schema/src/test/resources/trip/v2/problem/json/tollRequest_ExcludedTollTypes.json
@@ -1,0 +1,5 @@
+{
+  "vehicleType": "TRUCK_WITH_TWO_SINGLE_AXIS",
+  "billing": "FREE_FLOW",
+  "excludedTollTypes": ["TOLL_GANTRY", "ENTRY_GANTRY"]
+}

--- a/trip-schema/src/test/resources/trip/v2/problem/json/tollRequest_Multiplier.json
+++ b/trip-schema/src/test/resources/trip/v2/problem/json/tollRequest_Multiplier.json
@@ -1,0 +1,5 @@
+{
+  "vehicleType": "TRUCK_WITH_TWO_SINGLE_AXIS",
+  "billing": "FREE_FLOW",
+  "multiplier": 3
+}


### PR DESCRIPTION
## Resumo

Implementação dos dois novos parâmetros introduzidos no toll-api neste SDK, com suporte tanto no módulo `toll-schema` quanto no `trip-schema`.

### `excludedTollTypes` (Set<TollType>)

Parâmetro de request que permite excluir tipos de pedágio do cálculo. Quando informado, a API ignora pedágios dos tipos listados ao montar o resultado.

- Adicionado em `TollCalculationRequest` (toll-schema)
- Adicionado em `TollRequest` (trip-schema)
- Default: `Set` vazio (nenhum tipo excluído)

### `multiplier` (Integer)

Valor multiplicador aplicado ao preço do pedágio. A API só aplica o multiplicador em pedágios que tenham `allowMultiplier = true` internamente. O valor efetivamente aplicado é retornado na resposta.

- Adicionado em `LegRequest` como parâmetro de request (toll-schema)
- Adicionado em `TollRequest` como parâmetro de request (trip-schema)
- Adicionado em `CalculationDetail` como campo de resposta — reflete o multiplicador que foi aplicado no cálculo
- Default: `null` (sem multiplicador)

### Testes

Adicionados testes de desserialização e fixtures JSON para todos os novos campos em ambos os módulos.