### PR TITLE
feat: [SPLT-2763] - adiciona campo currency em CalculationDetail

### DIFF
--- a/toll-schema/src/main/java/global/maplink/toll/schema/result/CalculationDetail.java
+++ b/toll-schema/src/main/java/global/maplink/toll/schema/result/CalculationDetail.java
@@ -24,6 +24,7 @@ public class CalculationDetail {
     private final String city;
     private final State state;
     private final String country;
+    private final String currency;
     private final String concession;
     private final TollDirection direction;
     private final MaplinkPoint coordinates;

--- a/toll-schema/src/test/java/global/maplink/toll/schema/result/CalculationDetailTest.java
+++ b/toll-schema/src/test/java/global/maplink/toll/schema/result/CalculationDetailTest.java
@@ -105,6 +105,53 @@ public class CalculationDetailTest {
     }
 
     @Test
+    void shouldBuildWithProvidedValues() {
+        MaplinkPoint coordinates = new MaplinkPoint(-23.5666499, -46.6557755);
+        State state = State.builder().name("Sao Paulo").code("SP").build();
+        TollServiceType serviceType = TollServiceType.builder().serviceId("301").name("Via Facil").build();
+
+        CalculationDetail detail = CalculationDetail.builder()
+                .id("123")
+                .type(EXIT_GANTRY)
+                .name("MAIN")
+                .address("calculationDetailAddress")
+                .city("Sao Paulo")
+                .state(state)
+                .country("Brasil")
+                .currency("REAL")
+                .concession("IDK")
+                .direction(TollDirection.NORTH)
+                .coordinates(coordinates)
+                .serviceTypes(Collections.singletonList(serviceType))
+                .price(new BigDecimal("59.7"))
+                .segmentId("35693564")
+                .entryGantryId("3569")
+                .entryGantryName("Pórtico - Entrada")
+                .active(true)
+                .multiplier(2)
+                .build();
+
+        assertEquals("123", detail.getId());
+        assertEquals(EXIT_GANTRY, detail.getType());
+        assertEquals("MAIN", detail.getName());
+        assertEquals("calculationDetailAddress", detail.getAddress());
+        assertEquals("Sao Paulo", detail.getCity());
+        assertEquals(state, detail.getState());
+        assertEquals("Brasil", detail.getCountry());
+        assertEquals("REAL", detail.getCurrency());
+        assertEquals("IDK", detail.getConcession());
+        assertEquals(TollDirection.NORTH, detail.getDirection());
+        assertEquals(coordinates, detail.getCoordinates());
+        assertEquals(Collections.singletonList(serviceType), detail.getServiceTypes());
+        assertEquals(0, new BigDecimal("59.7").compareTo(detail.getPrice()));
+        assertEquals("35693564", detail.getSegmentId());
+        assertEquals("3569", detail.getEntryGantryId());
+        assertEquals("Pórtico - Entrada", detail.getEntryGantryName());
+        assertTrue(detail.isActive());
+        assertEquals(2, detail.getMultiplier());
+    }
+
+    @Test
     void shouldDeserializeActiveField() {
         CalculationDetail calculationDetail = mapper.fromJson(CALCULATION_DETAIL.load(), CalculationDetail.class);
 

--- a/toll-schema/src/test/java/global/maplink/toll/schema/result/CalculationDetailTest.java
+++ b/toll-schema/src/test/java/global/maplink/toll/schema/result/CalculationDetailTest.java
@@ -96,11 +96,12 @@ public class CalculationDetailTest {
     }
 
     @Test
-    void shouldDefaultCurrencyToNullWhenAbsent() {
-        byte[] json = "{\"id\":\"1\",\"name\":\"NO_CURRENCY\"}".getBytes();
-        CalculationDetail result = mapper.fromJson(json, CalculationDetail.class);
+    void shouldDefaultOptionalFieldsWhenNotSet() {
+        CalculationDetail detail = CalculationDetail.builder().build();
 
-        assertNull(result.getCurrency());
+        assertNull(detail.getCurrency());
+        assertNull(detail.getMultiplier());
+        assertFalse(detail.isActive());
     }
 
     @Test

--- a/toll-schema/src/test/java/global/maplink/toll/schema/result/CalculationDetailTest.java
+++ b/toll-schema/src/test/java/global/maplink/toll/schema/result/CalculationDetailTest.java
@@ -34,6 +34,7 @@ public class CalculationDetailTest {
         assertEquals("SP", calculationDetail.getState().getCode());
 
         assertEquals("Brasil", calculationDetail.getCountry());
+        assertEquals("REAL", calculationDetail.getCurrency());
         assertEquals("IDK", calculationDetail.getConcession());
         assertEquals(TollDirection.NORTH, calculationDetail.getDirection());
 
@@ -88,9 +89,18 @@ public class CalculationDetailTest {
 
         assertEquals(0, new BigDecimal("616.0").compareTo(result.getPrice()));
         assertEquals(EXIT_GANTRY, result.getType());
+        assertEquals("PESO", result.getCurrency());
         assertEquals("35693564", result.getSegmentId());
         assertEquals("3569", result.getEntryGantryId());
         assertEquals("Pórtico - Entrada - Martín de Zamora", result.getEntryGantryName());
+    }
+
+    @Test
+    void shouldDefaultCurrencyToNullWhenAbsent() {
+        byte[] json = "{\"id\":\"1\",\"name\":\"NO_CURRENCY\"}".getBytes();
+        CalculationDetail result = mapper.fromJson(json, CalculationDetail.class);
+
+        assertNull(result.getCurrency());
     }
 
     @Test

--- a/toll-schema/src/test/java/global/maplink/toll/schema/result/TollCalculationResultTest.java
+++ b/toll-schema/src/test/java/global/maplink/toll/schema/result/TollCalculationResultTest.java
@@ -25,6 +25,7 @@ class TollCalculationResultTest {
         val firstLeg = data.getLegs().get(0);
         assertThat(firstLeg.getLegTotalCost()).isCloseTo(TEN, offset(OFFSET));
         assertThat(firstLeg.getTolls()).hasSize(1).first().extracting(CalculationDetail::getId).isEqualTo("123");
+        assertThat(firstLeg.getTolls()).first().extracting(CalculationDetail::getCurrency).isEqualTo("REAL");
 
     }
 }

--- a/toll-schema/src/test/resources/toll/json/calculationDetail.json
+++ b/toll-schema/src/test/resources/toll/json/calculationDetail.json
@@ -8,6 +8,7 @@
     "code": "SP"
   },
   "country": "Brasil",
+  "currency": "REAL",
   "concession": "IDK",
   "direction": "NORTH",
   "coordinates": {

--- a/toll-schema/src/test/resources/toll/json/calculationResult.json
+++ b/toll-schema/src/test/resources/toll/json/calculationResult.json
@@ -12,6 +12,7 @@
             "code": "RJ"
           },
           "country": "Brasil",
+          "currency": "REAL",
           "concession": "teste",
           "direction": "NORTHEAST",
           "coordinates": {

--- a/toll-schema/src/test/resources/toll/json/exitGantryDetail.json
+++ b/toll-schema/src/test/resources/toll/json/exitGantryDetail.json
@@ -9,6 +9,7 @@
     "code": " "
   },
   "country": "Chile",
+  "currency": "PESO",
   "concession": "Autopista Vespucio Oriente",
   "direction": "NORTH",
   "coordinates": {


### PR DESCRIPTION
Atualiza para o novo modelo da toll-api que passou a retornar `currency` (ex.: "REAL", "PESO") em cada CalculationDetail da resposta de POST /v1/calculations.
